### PR TITLE
fix: force new version

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,3 @@
 {
-    "packages": [
-        "packages/*"
-    ],
-    "version": "2.6.0"
+  "version": "2.6.0"
 }

--- a/packages/openapi-node-client-generator-cli-template/README.md
+++ b/packages/openapi-node-client-generator-cli-template/README.md
@@ -1,3 +1,4 @@
-# Dependencies Dev
+# @forsakringskassan/openapi-node-client-generator-cli-template 
+## Dependencies Dev
 
 This is here so that dependencies are updated automatically with tools like Renovate.

--- a/packages/openapi-node-client-generator-cli/README.md
+++ b/packages/openapi-node-client-generator-cli/README.md
@@ -1,0 +1,1 @@
+# @forsakringskassan/openapi-node-client-generator-cli

--- a/packages/openapi-node-generator-cli-npm/README.md
+++ b/packages/openapi-node-generator-cli-npm/README.md
@@ -1,4 +1,5 @@
-# Downloader
+# @forsakringskassan/openapi-node-generator-cli-npm
+
+## Downloader
 
 When working within an organization you typically don't have open access to anything. This will download the Openapi Generator CLI so that it can be packaged into our CLI-tool. A user of the CLI tool will get it inside that NPM-package.
-


### PR DESCRIPTION
Seems that sub packages of v2.6.0 was not published to npm, so we need to force a new version to be published.